### PR TITLE
Update settings.service.js

### DIFF
--- a/app/www/js/settings/settings.service.js
+++ b/app/www/js/settings/settings.service.js
@@ -24,7 +24,7 @@
 			playerID					: localStorage.getObject('playerID', undefined),
 			recentGames				: localStorage.getObject('recentGames', 3),
 			showBadges				: setting('showBadges', true),
-			showElo						: setting('showElo', false),
+			showElo						: setting('showElo', true),
 			showRelTimes			: setting('showRelTimes', true),
 			useLocalDb				: setting('useLocalDb', isLocalhost()),
 			//Functions


### PR DESCRIPTION
changed default behavior to show elo because I don't want to turn it back on each time i update the app.
